### PR TITLE
feat: Add custom 404 page support, enhance dev server & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,20 @@ WingTip turns a `README.md` and a `docs/` folder into a polished static site —
 
 ```bash
 pip install markdown beautifulsoup4 livereload pillow
+# Alternatively, using uv (a fast Python package installer)
+uv pip install markdown beautifulsoup4 livereload pillow
 python wingtip/main.py
-python wingtip/serve.py  # (Use this, not python serve.py)
+python wingtip/serve.py
 ```
+
+To stop the development server, press `Ctrl+C` in the terminal where it's running.
+
+If you encounter issues stopping the server or suspect orphaned processes, a utility script `killDocs.sh` is provided in the `wingtip` directory. From your project root, you can run it using:
+
+```bash
+bash wingtip/killDocs.sh
+```
+This script will attempt to forcefully stop any processes related to the WingTip development server.
 
 Then open [http://localhost:8000](http://localhost:8000)
 
@@ -54,7 +65,7 @@ your-project/
 │   ├── serve.py
 │   ├── generate_card.py
 │   ├── template.html
-│   └── pygments.css
+├── pygments.css
 └── config.json          # Required if using social cards or favicon (see below)
 ```
 
@@ -107,7 +118,7 @@ WingTip includes a GitHub Actions workflow that builds and deploys your site aut
 
 ### Included Workflow
 
-`.github/workflows/pages.yml`:
+`.github/workflows/static.yml`:
 
 ```yaml
 name: Deploy static content to Pages
@@ -148,7 +159,7 @@ jobs:
           pip install markdown Pygments Pillow beautifulsoup4
 
       - name: Build site
-        run: python main.py
+        run: python wingtip/main.py
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -180,6 +191,19 @@ python wingtip/main.py --regen-card
 
 ---
 
+## Custom 404 Page
+
+WingTip supports a custom "Page Not Found" page. To use this feature:
+
+1.  Create a `404.md` file in the root of your project directory (the same directory where your `README.md` and `config.json` are located).
+2.  Write your desired content for the 404 page in Markdown format within this file.
+    *   The title for the generated `404.html` page will be taken from the first H1 heading (e.g., `# My Custom 404 Page`) in your `404.md`. If no H1 heading is found, the title will default to "404.md".
+3.  When you build your site, WingTip will automatically detect `404.md` and convert it into a `404.html` file in your output directory (e.g., `docs/site/404.html`).
+
+This `404.html` file can then be configured with your web hosting provider (like GitHub Pages, Netlify, Vercel, etc.) to be served whenever a visitor tries to access a non-existent page on your site.
+
+---
+
 ## Theming and UX
 
 * Auto light/dark theme based on system preference
@@ -205,6 +229,7 @@ python wingtip/main.py --regen-card
     ├── index.html
     ├── guide.html
     ├── api.html
+    ├── 404.html
     └── social-card.png
 ```
 
@@ -218,9 +243,7 @@ pip install markdown beautifulsoup4 pillow livereload
 
 To regenerate code highlight styles:
 
-```bash
-pygmentize -S default -f html > wingtip/pygments.css
-```
+The file `syntax.css` is generated in `docs/site/` by `main.py` and is the one used by the site. The `pygments.css` file in the root directory might be for reference or manual generation using a command like `pygmentize -S monokai -f html -O full,cssclass=highlight > pygments.css` (using monokai as an example, to match one of the themes).
 
 ---
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "base_url": "https://semanticentity.github.io/WingTip-Static-Site-Generator",
     "project_name": "WingTip",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "SEO-friendly Markdown-to-HTML static site generator for GitHub Pages",
     "author": "SemanticEntity",
     "repo_url": "https://github.com/semanticentity/WingTip-Static-Site-Generator/",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,4 +29,4 @@
 - Full quickstart and config guide
 - GitHub Pages deployment with prebuilt `pages.yml`
 - Example `config.json` for SEO and appearance
-- Theme toggle, TOC keyboard shortcut (`Alt+D`), and favicon support
+- Theme toggle and favicon support

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,28 @@
 # WingTip Changelog
 
+## [v0.2.0]
+
+### ✨ Features
+- Added support for custom 404 pages: Users can create a `404.md` in the project root, which will be converted to `docs/site/404.html` and included in the sitemap.
+
+### 🛠 Fixes & Improvements
+- Corrected path handling in `main.py` and `serve.py` to ensure proper functionality when WingTip is used as a nested module (e.g., running `python wingtip/main.py` from a parent project directory).
+- Refined `killDocs.sh` script:
+    - Now attempts a graceful process termination (SIGTERM) before resorting to a forceful one (SIGKILL).
+    - Removed obsolete PID file handling logic.
+- Removed an unused internal function (`write_docs_index`) from `main.py`.
+- Removed a duplicate inclusion of `clipboard.js` in `template.html`.
+
+### 📚 Documentation
+- Updated `README.md` to accurately reflect nested project structure usage (e.g., `wingtip/main.py` for commands and file paths).
+- Clarified `syntax.css` (generated) vs. `pygments.css` (manual reference) in `README.md`.
+- Corrected the GitHub Actions workflow example in `README.md` to use `python wingtip/main.py`.
+- Added `uv` pip install instructions as an alternative in `README.md`.
+- Documented the new custom 404 page feature in `README.md`.
+- Documented how to stop the development server (Ctrl+C) and the purpose/usage of `killDocs.sh` in `README.md`.
+- Corrected `main.py` help text for sitemap generation and removed outdated notes.
+- Removed mention of a non-implemented "TOC keyboard shortcut (`Alt+D`)" from this changelog (v0.1.0 entry).
+
 ## [v0.1.0](#v010)
 
 ### ✨ Features

--- a/serve.py
+++ b/serve.py
@@ -12,21 +12,19 @@ from livereload import Server
 
 # Get absolute paths
 BASE_DIR = Path(__file__).parent
-SITE_DIR = BASE_DIR / "docs" / "site"
+SITE_DIR = Path("docs") / "site"
 PORT = 8000
 
 def build_site():
     """Build the site and return True if successful"""
     print("\n🔨 Building site...")
-    # Always run from the correct directory
-    os.chdir(str(BASE_DIR))
     
     try:
         # Try building in a temporary directory first
-        tmp_dir = "docs/site_tmp"
+        tmp_dir = "docs_site_tmp"
         os.makedirs(tmp_dir, exist_ok=True)
         result = subprocess.run(
-            ["python", "main.py", "--output", tmp_dir],
+            ["python", str(BASE_DIR / "main.py"), "--output", tmp_dir],
             capture_output=True,
             text=True
         )
@@ -35,7 +33,7 @@ def build_site():
             print("  ✓ Build successful")
             # If successful, rebuild for real
             result = subprocess.run(
-                ["python", "main.py"],
+                ["python", str(BASE_DIR / "main.py")],
                 capture_output=True,
                 text=True
             )
@@ -66,8 +64,8 @@ if __name__ == "__main__":
     # Watch for changes
     server.watch("README.md", build_site)
     server.watch("docs/*.md", build_site)
-    server.watch("template.html", build_site)
-    server.watch("main.py", build_site)
+    server.watch(str(BASE_DIR / "template.html"), build_site)
+    server.watch(str(BASE_DIR / "main.py"), build_site)
     
     # Serve the site
     print(f"\n🌐 Starting server at http://localhost:{PORT}")

--- a/template.html
+++ b/template.html
@@ -39,7 +39,6 @@
 
   <!-- Code block copy button -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.8/clipboard.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.8/clipboard.min.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       // Initialize clipboard.js


### PR DESCRIPTION
- Implements custom 404 page generation from `404.md`.
- Refines `killDocs.sh` utility for stopping the dev server and updates related README sections.
- Improves path handling in `serve.py` and `main.py` for robust nested execution.
- General `README.md` cleanup for accuracy and clarity (Quickstart, file paths, GitHub Actions example, `uv` install).
