### PR TITLE
Fix: Correct search_index.json path for GitHub Pages

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -12,7 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
     resultsContainer.style.display = 'none';
   }
 
-  fetch('/search_index.json')
+  const searchIndexPath = (window.SITE_BASE_URL && window.SITE_BASE_URL !== '.' ? window.SITE_BASE_URL : '') + '/search_index.json';
+  fetch(searchIndexPath)
     .then(response => {
       if (!response.ok) {
         throw new Error('Network response was not ok for search_index.json');

--- a/template.html
+++ b/template.html
@@ -1205,6 +1205,9 @@ html.dark #search-results-container li.active-search-result .search-result-snipp
     });
   </script>
   <script id="raw-markdown-data" type="text/markdown">$raw_markdown_content</script>
+  <script>
+    window.SITE_BASE_URL = '$base_url';
+  </script>
   <script src="static/js/search.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
The search functionality was failing on GitHub Pages because the path to `search_index.json` was hardcoded as `/search_index.json`. This caused a 404 error as the file is actually located at `/<repo_name>/search_index.json` on GitHub Pages.

This commit addresses the issue by:
1. Injecting the `base_url` from `config.json` into `template.html` as a global JavaScript variable `window.SITE_BASE_URL`.
2. Modifying `static/js/search.js` to use `window.SITE_BASE_URL` to construct the correct path to `search_index.json`.

This ensures the search index is loaded correctly for both local development (where base_url might be '.') and when deployed to GitHub Pages or other subdirectory-based hosting.