### PR TITLE
Refactor: Adjust navbar search breakpoint for improved mobile friendl…

### DIFF
--- a/template.html
+++ b/template.html
@@ -811,7 +811,7 @@ html.dark #search-results-container li a:hover {
 }
 
 /* Responsive adjustments for search */
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .search-wrapper {
     flex-grow: 1;
     margin-left: 0.5em; /* Give a bit of space from nav-links brand */


### PR DESCRIPTION
…iness

The media query breakpoint for mobile-specific search bar styling has been changed from 600px to 768px in template.html.

This change allows the search input to adopt a flexible, full-width behavior (within its navbar constraints) on a wider range of devices, including common tablet portrait screen sizes. Previously, screens between 601px and 768px would display a fixed-width (200px) search input, which could appear too small or cause layout crowding.

With this update:
- Screens 768px wide or narrower will now display a search bar that grows to fill available space between the brand logo and theme toggle.
- Screens wider than 768px will continue to use the fixed-width search input as before.

This enhances your experience on small to medium-sized screens by making the search functionality more prominent and accessible.